### PR TITLE
included unistd.h for usleep

### DIFF
--- a/src/rntlib/pcelib.c
+++ b/src/rntlib/pcelib.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "pcelib.h"
 #include "requests.h"
 #include "hexdump.h"


### PR DESCRIPTION
Hi, I recently bought a GC to USB v3 and started tinkering yesterday. I compiled this for Arch and noticed any attempt to update the firmware through the gui failed. This fixes the issue (unistd.h is not included in pcelib.c, so the usleep function you use does nothing). I hope this helps :)