### PR TITLE
Deps for firmware update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ There are a few dependencies:
  - libgtk-3-dev (for the gui only)
  - libxml2-utils (for the gui)
 
+The gui also has run-time dependencies:
+ - dfu-programmer (for firmware updates)
+
 Provided you have all the dependencies installed, under Linux at least, it should
 compile without errors. For other environments such has MinGW, there are provisions
 in the makefile to auto-detect and tweak the build accordingly, but it if fails, be


### PR DESCRIPTION
Hi again!
dfu-programmer is not listed as a dependency because is it not required for the software to compile, but it is definitely necessary for firmware updates in the gui. Reading that in the readme would have saved me a lot of time :D