### PR TITLE
Fix/preserve note header on import

### DIFF
--- a/src/rntlib/mempak.c
+++ b/src/rntlib/mempak.c
@@ -119,6 +119,10 @@ int mempak_importNote(mempak_structure_t *mpk, const char *notefile, int dst_not
 		entry_data[0x06] = 0x00;
 		entry_data[0x07] = 0x05; // BLOCK_VALID_FIRST;
 
+		// Clear first so entry.raw_valid cannot be read uninitialized if
+		// mempak_parse_entry ever bails out before setting it.
+		memset(&entry, 0, sizeof(entry));
+
 		if (0 != mempak_parse_entry(entry_data, &entry)) {
 			fprintf(stderr, "Error loading note (invalid)\n");
 			fclose(fptr);

--- a/src/rntlib/mempak_fs.c
+++ b/src/rntlib/mempak_fs.c
@@ -473,6 +473,7 @@ int mempak_parse_entry( const uint8_t *tnote, entry_structure_t *note )
     note->vendor = (tnote[0] << 16) | (tnote[1] << 8) | (tnote[2]);
     note->region = tnote[3];
 	memcpy(note->raw_data, tnote, 32);
+	note->raw_valid = 1;
 
     /* Important stuff */
     note->game_id = (tnote[4] << 8) | (tnote[5]);
@@ -541,6 +542,24 @@ static int __write_note( entry_structure_t *note, uint8_t *out_note )
 {
     wchar_t tname[19];
     if( !out_note || !note ) { return -1; }
+
+    if( note->raw_valid )
+    {
+        /* This note already has a header, so keep it byte for byte. A game
+         * finds its save by matching the game code and publisher code stored
+         * here, so rebuilding those fields from scratch would orphan the note.
+         * Only the inode changes: the blocks were just reallocated.
+         *
+         * This also preserves the name and extension exactly. Rebuilding them
+         * below is lossy, because the round trip through wchar_t maps the NUL
+         * padding official saves use onto 0x0F (space). */
+        memcpy( out_note, note->raw_data, 32 );
+
+        out_note[6] = (note->inode >> 8) & 0xFF;
+        out_note[7] = note->inode & 0xFF;
+
+        return 0;
+    }
 
     /* Start with baseline */
     memset( out_note, 0, 32 );
@@ -1149,10 +1168,18 @@ int write_mempak_entry_data( mempak_structure_t *mpk, entry_structure_t *entry, 
         /* Last now contains our inode */
         entry->inode = last;
         entry->valid = 0;
-        entry->vendor = 0;
 
-        /* A value observed in most games */
-        entry->game_id = 0x4535;
+        if( !entry->raw_valid )
+        {
+            /* Nothing to preserve, so fall back to a generic header. Only do
+             * this for entries built from scratch: clobbering these on a note
+             * that came from a mempak would throw away the identity the game
+             * uses to find its save. */
+            entry->vendor = 0;
+
+            /* A value observed in most games */
+            entry->game_id = 0x4535;
+        }
     }
 
     /* Loop through allocated blocks and write data to sectors */

--- a/src/rntlib/mempak_fs.h
+++ b/src/rntlib/mempak_fs.h
@@ -65,6 +65,15 @@ typedef struct entry_structure
 
 	/** @brief A copy of the raw note data (from the note table). */
 	unsigned char raw_data[32];
+
+	/** @brief Non-zero when raw_data holds a real note header.
+	 *
+	 * Set by #mempak_parse_entry. When set, #write_mempak_entry_data preserves
+	 * the original header bytes rather than synthesizing a new one, so that a
+	 * note taken out of a mempak and put back keeps its game code, publisher
+	 * code and region. Entries built from scratch leave this at 0 and get the
+	 * generic header instead. */
+	unsigned char raw_valid;
 } entry_structure_t;
 
 #ifdef __cplusplus

--- a/src/rntlib/strcasestr.h
+++ b/src/rntlib/strcasestr.h
@@ -1,5 +1,5 @@
 #ifndef _strcasestr_h__
-#define _strcasestr_h_-
+#define _strcasestr_h__
 
 char *strcasestr(const char *haystack, const char *needle);
 


### PR DESCRIPTION
Fixes an issue discovered using mempak_insert_note.exe, where inserting a single note into a mpk file causes the game code / publisher header of the note to get lost, appears to be writing a default placeholder.

Example test:
Trying to insert this note: (header value N2VEBB):
<img width="477" height="302" alt="note" src="https://github.com/user-attachments/assets/2a331c56-56e3-4cbd-bbdd-7106294fc88c" />

After inserting into mpk file, note header is lost (..EE5):
<img width="478" height="317" alt="before" src="https://github.com/user-attachments/assets/1c325b44-ba0e-465e-a258-e8c2e58bce93" />

After fix is applied, inserting note into mpk and N2VEBB header is preserved:
<img width="481" height="295" alt="fixed" src="https://github.com/user-attachments/assets/836b0cf1-9e42-4bd5-a7b4-a603a5e1aad2" />
